### PR TITLE
게시글 목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.rest-assured:spring-web-test-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wanted/sns/SnsApplication.java
+++ b/src/main/java/com/wanted/sns/SnsApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class SnsApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SnsApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(SnsApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/wanted/sns/controller/PostController.java
+++ b/src/main/java/com/wanted/sns/controller/PostController.java
@@ -6,6 +6,7 @@ import com.wanted.sns.service.PostService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,11 +15,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PostController {
 
-  private final PostService postService;
+    private final PostService postService;
 
-  @GetMapping
-  public List<PostResponse> getPostList(PostRequest postRequest){
-    return postService.getPostList(postRequest);
-  }
+    @GetMapping
+    public List<PostResponse> getPostList(PostRequest postRequest) {
+        return postService.getPostList(postRequest);
+    }
+
+    @GetMapping("/{id}")
+    public PostResponse getPost(@PathVariable("id") long seq) {
+        return postService.getPost(seq);
+    }
 
 }

--- a/src/main/java/com/wanted/sns/controller/PostController.java
+++ b/src/main/java/com/wanted/sns/controller/PostController.java
@@ -6,7 +6,6 @@ import com.wanted.sns.service.PostService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,11 +19,6 @@ public class PostController {
     @GetMapping
     public List<PostResponse> getPostList(PostRequest postRequest) {
         return postService.getPostList(postRequest);
-    }
-
-    @GetMapping("/{id}")
-    public PostResponse getPost(@PathVariable("id") long seq) {
-        return postService.getPost(seq);
     }
 
 }

--- a/src/main/java/com/wanted/sns/controller/PostController.java
+++ b/src/main/java/com/wanted/sns/controller/PostController.java
@@ -1,0 +1,24 @@
+package com.wanted.sns.controller;
+
+import com.wanted.sns.dto.PostRequest;
+import com.wanted.sns.dto.PostResponse;
+import com.wanted.sns.service.PostService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/post")
+@RestController
+public class PostController {
+
+  private final PostService postService;
+
+  @GetMapping
+  public List<PostResponse> getPostList(PostRequest postRequest){
+    return postService.getPostList(postRequest);
+  }
+
+}

--- a/src/main/java/com/wanted/sns/controller/PostController.java
+++ b/src/main/java/com/wanted/sns/controller/PostController.java
@@ -5,6 +5,8 @@ import com.wanted.sns.dto.PostResponse;
 import com.wanted.sns.service.PostService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,8 +19,9 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public List<PostResponse> getPostList(PostRequest postRequest) {
-        return postService.getPostList(postRequest);
+    public ResponseEntity<List<PostResponse>> getPostList(PostRequest postRequest) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(postService.getPostList(postRequest));
     }
 
 }

--- a/src/main/java/com/wanted/sns/domain/Hashtag.java
+++ b/src/main/java/com/wanted/sns/domain/Hashtag.java
@@ -1,7 +1,14 @@
 package com.wanted.sns.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @AllArgsConstructor
@@ -10,10 +17,10 @@ import lombok.*;
 @Entity
 public class Hashtag {
 
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Id
-  private long seq;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private long seq;
 
-  private String name;
+    private String name;
 
 }

--- a/src/main/java/com/wanted/sns/domain/Hashtag.java
+++ b/src/main/java/com/wanted/sns/domain/Hashtag.java
@@ -1,0 +1,19 @@
+package com.wanted.sns.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Hashtag {
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Id
+  private long seq;
+
+  private String name;
+
+}

--- a/src/main/java/com/wanted/sns/domain/HashtagMapping.java
+++ b/src/main/java/com/wanted/sns/domain/HashtagMapping.java
@@ -1,7 +1,17 @@
 package com.wanted.sns.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @AllArgsConstructor
@@ -10,16 +20,16 @@ import lombok.*;
 @Entity
 public class HashtagMapping {
 
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Id
-  private long seq;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private long seq;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "seq_post", referencedColumnName = "seq")
-  private Post post;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seq_post", referencedColumnName = "seq")
+    private Post post;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "seq_hashtag", referencedColumnName = "seq")
-  private Hashtag hashtag;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seq_hashtag", referencedColumnName = "seq")
+    private Hashtag hashtag;
 
 }

--- a/src/main/java/com/wanted/sns/domain/HashtagMapping.java
+++ b/src/main/java/com/wanted/sns/domain/HashtagMapping.java
@@ -1,0 +1,25 @@
+package com.wanted.sns.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class HashtagMapping {
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Id
+  private long seq;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "seq_post", referencedColumnName = "seq")
+  private Post post;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "seq_hashtag", referencedColumnName = "seq")
+  private Hashtag hashtag;
+
+}

--- a/src/main/java/com/wanted/sns/domain/Order.java
+++ b/src/main/java/com/wanted/sns/domain/Order.java
@@ -1,0 +1,7 @@
+package com.wanted.sns.domain;
+
+public enum Order {
+
+  ASC, DESC
+
+}

--- a/src/main/java/com/wanted/sns/domain/Order.java
+++ b/src/main/java/com/wanted/sns/domain/Order.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum Order {
 
-    ASC("asc"), DESC("desc");
+    ASC("asc"),
+    DESC("desc");
 
     private final String value;
 

--- a/src/main/java/com/wanted/sns/domain/Order.java
+++ b/src/main/java/com/wanted/sns/domain/Order.java
@@ -2,6 +2,6 @@ package com.wanted.sns.domain;
 
 public enum Order {
 
-  ASC, DESC
+    ASC, DESC
 
 }

--- a/src/main/java/com/wanted/sns/domain/Order.java
+++ b/src/main/java/com/wanted/sns/domain/Order.java
@@ -1,7 +1,16 @@
 package com.wanted.sns.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum Order {
 
-    ASC, DESC
+    ASC("asc"), DESC("desc");
+
+    private final String value;
+
+    Order(String value) {
+        this.value = value;
+    }
 
 }

--- a/src/main/java/com/wanted/sns/domain/Post.java
+++ b/src/main/java/com/wanted/sns/domain/Post.java
@@ -1,5 +1,6 @@
 package com.wanted.sns.domain;
 
+import com.wanted.sns.dto.PostResponse;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -15,28 +16,28 @@ import lombok.Getter;
 @Entity
 public class Post {
 
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Id
-  private long seq;
+    @OneToMany(mappedBy = "post")
+    List<HashtagMapping> hashtagMappingList;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private long seq;
+    @Enumerated(EnumType.STRING)
+    private SnsType type;
+    private String title;
+    private String content;
+    private int viewCount;
+    private int likeCount;
+    private int shareCount;
+    private LocalDateTime updatedAt;
+    private LocalDateTime createdAt;
 
-  @Enumerated(EnumType.STRING)
-  private SnsType type;
+    public PostResponse toDTO() {
+        increaseViewCount();
+        return new PostResponse(this);
+    }
 
-  private String title;
-
-  private String content;
-
-  private int viewCount;
-
-  private int likeCount;
-
-  private int shareCount;
-
-  private LocalDateTime updatedAt;
-
-  private LocalDateTime createdAt;
-
-  @OneToMany(mappedBy = "post")
-  List<HashtagMapping> hashtagMappingList;
+    public void increaseViewCount() {
+        viewCount++;
+    }
 
 }

--- a/src/main/java/com/wanted/sns/domain/Post.java
+++ b/src/main/java/com/wanted/sns/domain/Post.java
@@ -1,6 +1,5 @@
 package com.wanted.sns.domain;
 
-import com.wanted.sns.dto.PostResponse;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -16,28 +15,28 @@ import lombok.Getter;
 @Entity
 public class Post {
 
-    @OneToMany(mappedBy = "post")
-    List<HashtagMapping> hashtagMappingList;
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private long seq;
+
     @Enumerated(EnumType.STRING)
     private SnsType type;
+
     private String title;
+
     private String content;
+
     private int viewCount;
+
     private int likeCount;
+
     private int shareCount;
+
     private LocalDateTime updatedAt;
+
     private LocalDateTime createdAt;
 
-    public PostResponse toDTO() {
-        increaseViewCount();
-        return new PostResponse(this);
-    }
-
-    public void increaseViewCount() {
-        viewCount++;
-    }
+    @OneToMany(mappedBy = "post")
+    List<HashtagMapping> hashtagMappingList;
 
 }

--- a/src/main/java/com/wanted/sns/domain/Post.java
+++ b/src/main/java/com/wanted/sns/domain/Post.java
@@ -1,0 +1,42 @@
+package com.wanted.sns.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Post {
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Id
+  private long seq;
+
+  @Enumerated(EnumType.STRING)
+  private SnsType type;
+
+  private String title;
+
+  private String content;
+
+  private int viewCount;
+
+  private int likeCount;
+
+  private int shareCount;
+
+  private LocalDateTime updatedAt;
+
+  private LocalDateTime createdAt;
+
+  @OneToMany(mappedBy = "post")
+  List<HashtagMapping> hashtagMappingList;
+
+}

--- a/src/main/java/com/wanted/sns/domain/SnsType.java
+++ b/src/main/java/com/wanted/sns/domain/SnsType.java
@@ -21,7 +21,7 @@ public enum SnsType {
 
     public static SnsType find(String value) {
         for (SnsType snsType : SnsType.values()) {
-            if (snsType.getValue().equals(value)) {
+            if (snsType.getValue().equalsIgnoreCase(value)) {
                 return snsType;
             }
         }

--- a/src/main/java/com/wanted/sns/domain/SnsType.java
+++ b/src/main/java/com/wanted/sns/domain/SnsType.java
@@ -1,0 +1,28 @@
+package com.wanted.sns.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum SnsType {
+
+  FACEBOOK("facebook"),
+  TWITTER("twitter"),
+  INSTAGRAM("instagram"),
+  THREADS("threads");
+
+  private final String value;
+
+  SnsType(String value) {
+    this.value = value;
+  }
+
+  public static SnsType find(String value) {
+    for (SnsType snsType : SnsType.values()) {
+      if (snsType.getValue().equals(value)) {
+        return snsType;
+      }
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/com/wanted/sns/domain/SnsType.java
+++ b/src/main/java/com/wanted/sns/domain/SnsType.java
@@ -6,8 +6,11 @@ import lombok.Getter;
 public enum SnsType {
 
     FACEBOOK("facebook"),
+
     TWITTER("twitter"),
+
     INSTAGRAM("instagram"),
+
     THREADS("threads");
 
     private final String value;

--- a/src/main/java/com/wanted/sns/domain/SnsType.java
+++ b/src/main/java/com/wanted/sns/domain/SnsType.java
@@ -5,24 +5,24 @@ import lombok.Getter;
 @Getter
 public enum SnsType {
 
-  FACEBOOK("facebook"),
-  TWITTER("twitter"),
-  INSTAGRAM("instagram"),
-  THREADS("threads");
+    FACEBOOK("facebook"),
+    TWITTER("twitter"),
+    INSTAGRAM("instagram"),
+    THREADS("threads");
 
-  private final String value;
+    private final String value;
 
-  SnsType(String value) {
-    this.value = value;
-  }
-
-  public static SnsType find(String value) {
-    for (SnsType snsType : SnsType.values()) {
-      if (snsType.getValue().equals(value)) {
-        return snsType;
-      }
+    SnsType(String value) {
+        this.value = value;
     }
-    return null;
-  }
+
+    public static SnsType find(String value) {
+        for (SnsType snsType : SnsType.values()) {
+            if (snsType.getValue().equals(value)) {
+                return snsType;
+            }
+        }
+        return null;
+    }
 
 }

--- a/src/main/java/com/wanted/sns/dto/PostRequest.java
+++ b/src/main/java/com/wanted/sns/dto/PostRequest.java
@@ -1,0 +1,28 @@
+package com.wanted.sns.dto;
+
+import com.wanted.sns.domain.Order;
+import lombok.Builder;
+
+public record PostRequest(String hashtag, String type, String order, String orderBy,
+                          String searchBy, String search, Integer pageCount, Integer page) {
+
+  @Builder
+  public PostRequest {
+    if (pageCount == null) {
+      pageCount = 10;
+    }
+
+    if (page == null || page < 0) {
+      page = 0;
+    }
+
+    if (order == null) {
+      order = Order.DESC.name();
+    }
+
+    if (orderBy == null) {
+      orderBy = "createdAt";
+    }
+  }
+
+}

--- a/src/main/java/com/wanted/sns/dto/PostRequest.java
+++ b/src/main/java/com/wanted/sns/dto/PostRequest.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 public record PostRequest(
         String hashtag, String type, String order, String orderBy,
         String searchBy, String search, Integer pageCount, Integer page) {
+
     @Builder
     public PostRequest {
         if (pageCount == null) {

--- a/src/main/java/com/wanted/sns/dto/PostRequest.java
+++ b/src/main/java/com/wanted/sns/dto/PostRequest.java
@@ -1,11 +1,9 @@
 package com.wanted.sns.dto;
 
 import com.wanted.sns.domain.Order;
-import jakarta.persistence.Column;
 import lombok.Builder;
 
 public record PostRequest(
-        @Column(nullable = false)
         String hashtag, String type, String order, String orderBy,
         String searchBy, String search, Integer pageCount, Integer page) {
     @Builder
@@ -19,7 +17,7 @@ public record PostRequest(
         }
 
         if (order == null) {
-            order = Order.DESC.name();
+            order = Order.DESC.getValue();
         }
 
         if (orderBy == null) {

--- a/src/main/java/com/wanted/sns/dto/PostRequest.java
+++ b/src/main/java/com/wanted/sns/dto/PostRequest.java
@@ -1,28 +1,30 @@
 package com.wanted.sns.dto;
 
 import com.wanted.sns.domain.Order;
+import jakarta.persistence.Column;
 import lombok.Builder;
 
-public record PostRequest(String hashtag, String type, String order, String orderBy,
-                          String searchBy, String search, Integer pageCount, Integer page) {
+public record PostRequest(
+        @Column(nullable = false)
+        String hashtag, String type, String order, String orderBy,
+        String searchBy, String search, Integer pageCount, Integer page) {
+    @Builder
+    public PostRequest {
+        if (pageCount == null) {
+            pageCount = 10;
+        }
 
-  @Builder
-  public PostRequest {
-    if (pageCount == null) {
-      pageCount = 10;
-    }
+        if (page == null || page < 0) {
+            page = 0;
+        }
 
-    if (page == null || page < 0) {
-      page = 0;
-    }
+        if (order == null) {
+            order = Order.DESC.name();
+        }
 
-    if (order == null) {
-      order = Order.DESC.name();
+        if (orderBy == null) {
+            orderBy = "createdAt";
+        }
     }
-
-    if (orderBy == null) {
-      orderBy = "createdAt";
-    }
-  }
 
 }

--- a/src/main/java/com/wanted/sns/dto/PostResponse.java
+++ b/src/main/java/com/wanted/sns/dto/PostResponse.java
@@ -12,39 +12,39 @@ import lombok.Getter;
 @Getter
 public class PostResponse {
 
-  long id;
+    long id;
 
-  String title;
+    String title;
 
-  String type;
+    String type;
 
-  String content;
+    String content;
 
-  int viewCount;
+    int viewCount;
 
-  int likeCount;
+    int likeCount;
 
-  int shareCount;
+    int shareCount;
 
-  List<String> hashtagList = new ArrayList<>();
+    List<String> hashtagList = new ArrayList<>();
 
-  LocalDateTime updatedAt;
+    LocalDateTime updatedAt;
 
-  LocalDateTime createdAt;
+    LocalDateTime createdAt;
 
-  public PostResponse(Post post){
-    id = post.getSeq();
-    title = post.getTitle();
-    type = post.getType().getValue();
-    content = post.getContent().substring(0,20);
-    viewCount = post.getViewCount();
-    likeCount = post.getLikeCount();
-    shareCount = post.getShareCount();
-    updatedAt = post.getUpdatedAt();
-    createdAt = post.getCreatedAt();
-    for(HashtagMapping hashtagMapping : post.getHashtagMappingList()){
-      hashtagList.add(hashtagMapping.getHashtag().getName());
+    public PostResponse(Post post) {
+        id = post.getSeq();
+        title = post.getTitle();
+        type = post.getType().getValue();
+        content = post.getContent().substring(0, 20);
+        viewCount = post.getViewCount();
+        likeCount = post.getLikeCount();
+        shareCount = post.getShareCount();
+        updatedAt = post.getUpdatedAt();
+        createdAt = post.getCreatedAt();
+        for (HashtagMapping hashtagMapping : post.getHashtagMappingList()) {
+            hashtagList.add(hashtagMapping.getHashtag().getName());
+        }
     }
-  }
 
 }

--- a/src/main/java/com/wanted/sns/dto/PostResponse.java
+++ b/src/main/java/com/wanted/sns/dto/PostResponse.java
@@ -1,0 +1,50 @@
+package com.wanted.sns.dto;
+
+import com.wanted.sns.domain.HashtagMapping;
+import com.wanted.sns.domain.Post;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PostResponse {
+
+  long id;
+
+  String title;
+
+  String type;
+
+  String content;
+
+  int viewCount;
+
+  int likeCount;
+
+  int shareCount;
+
+  List<String> hashtagList = new ArrayList<>();
+
+  LocalDateTime updatedAt;
+
+  LocalDateTime createdAt;
+
+  public PostResponse(Post post){
+    id = post.getSeq();
+    title = post.getTitle();
+    type = post.getType().getValue();
+    content = post.getContent();
+    viewCount = post.getViewCount();
+    likeCount = post.getLikeCount();
+    shareCount = post.getShareCount();
+    updatedAt = post.getUpdatedAt();
+    createdAt = post.getCreatedAt();
+    for(HashtagMapping hashtagMapping : post.getHashtagMappingList()){
+      hashtagList.add(hashtagMapping.getHashtag().getName());
+    }
+  }
+
+}

--- a/src/main/java/com/wanted/sns/dto/PostResponse.java
+++ b/src/main/java/com/wanted/sns/dto/PostResponse.java
@@ -36,7 +36,7 @@ public class PostResponse {
     id = post.getSeq();
     title = post.getTitle();
     type = post.getType().getValue();
-    content = post.getContent();
+    content = post.getContent().substring(0,20);
     viewCount = post.getViewCount();
     likeCount = post.getLikeCount();
     shareCount = post.getShareCount();

--- a/src/main/java/com/wanted/sns/repository/PostCustomRepository.java
+++ b/src/main/java/com/wanted/sns/repository/PostCustomRepository.java
@@ -2,11 +2,10 @@ package com.wanted.sns.repository;
 
 import com.wanted.sns.dto.PostRequest;
 import com.wanted.sns.dto.PostResponse;
-
 import java.util.List;
 
 public interface PostCustomRepository {
 
-  List<PostResponse> findAllPostBy(PostRequest postRequest);
+    List<PostResponse> findAllPostBy(PostRequest postRequest);
 
 }

--- a/src/main/java/com/wanted/sns/repository/PostCustomRepository.java
+++ b/src/main/java/com/wanted/sns/repository/PostCustomRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.sns.repository;
+
+import com.wanted.sns.dto.PostRequest;
+import com.wanted.sns.dto.PostResponse;
+
+import java.util.List;
+
+public interface PostCustomRepository {
+
+  List<PostResponse> findAllPostBy(PostRequest postRequest);
+
+}

--- a/src/main/java/com/wanted/sns/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/wanted/sns/repository/PostCustomRepositoryImpl.java
@@ -42,8 +42,10 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         }
 
         List<Post> result = entityManager.createQuery(
-                        buildCommonQuery(postRequest, searchCriteria, builder, post, query)).setFirstResult(pageOffset)
-                .setMaxResults(postRequest.pageCount()).getResultList();
+                        buildCommonQuery(postRequest, searchCriteria, builder, post, query)
+                ).setFirstResult(pageOffset)
+                .setMaxResults(postRequest.pageCount())
+                .getResultList();
 
         return result.stream().map(PostResponse::new).collect(Collectors.toList());
     }
@@ -63,7 +65,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         }
 
         return entityManager.createQuery(
-                buildCommonQuery(postRequest, searchCriteria, builder, post, query)).getResultList();
+                buildCommonQuery(postRequest, searchCriteria, builder, post, query)
+        ).getResultList();
     }
 
 

--- a/src/main/java/com/wanted/sns/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/wanted/sns/repository/PostCustomRepositoryImpl.java
@@ -89,11 +89,11 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
         query.where(builder.and(searchCriteria.toArray(new Predicate[0])));
 
-        if (postRequest.order().equals(Order.ASC.name())) {
+        if (postRequest.order().equals(Order.ASC.getValue())) {
             query.orderBy(builder.asc(post.get(postRequest.orderBy())));
         }
 
-        if (postRequest.order().equals(Order.DESC.name())) {
+        if (postRequest.order().equals(Order.DESC.getValue())) {
             query.orderBy(builder.desc(post.get(postRequest.orderBy())));
         }
 

--- a/src/main/java/com/wanted/sns/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/wanted/sns/repository/PostCustomRepositoryImpl.java
@@ -20,83 +20,83 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostCustomRepositoryImpl implements PostCustomRepository {
 
-  private final EntityManager entityManager;
+    private final EntityManager entityManager;
 
-  @Override
-  public List<PostResponse> findAllPostBy(PostRequest postRequest) {
-    CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<PostResponse> query = builder.createQuery(PostResponse.class);
-    Root<Post> post = query.from(Post.class);
+    @Override
+    public List<PostResponse> findAllPostBy(PostRequest postRequest) {
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<PostResponse> query = builder.createQuery(PostResponse.class);
+        Root<Post> post = query.from(Post.class);
 
-    int pageOffset = postRequest.page() * postRequest.pageCount();
-    List<Predicate> searchCriteria = new ArrayList<>();
+        int pageOffset = postRequest.page() * postRequest.pageCount();
+        List<Predicate> searchCriteria = new ArrayList<>();
 
-    query.select(builder.construct(PostResponse.class, post));
+        query.select(builder.construct(PostResponse.class, post));
 
-    if (postRequest.hashtag() != null) {
-      searchCriteria.add(post.get("seq").in(findAllPostByHashtag(postRequest)));
+        if (postRequest.hashtag() != null) {
+            searchCriteria.add(post.get("seq").in(findAllPostByHashtag(postRequest)));
+        }
+
+        return entityManager
+                .createQuery(buildCommonQuery(postRequest, searchCriteria, builder, post, query))
+                .setFirstResult(pageOffset)
+                .setMaxResults(postRequest.pageCount())
+                .getResultList();
     }
 
-    return entityManager
-        .createQuery(buildCommonQuery(postRequest, searchCriteria, builder, post, query))
-        .setFirstResult(pageOffset)
-        .setMaxResults(postRequest.pageCount())
-        .getResultList();
-  }
+    public List<PostResponse> findAllPostByHashtag(PostRequest postRequest) {
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = builder.createQuery(Long.class);
+        Root<Post> post = query.from(Post.class);
+        List<Predicate> searchCriteria = new ArrayList<>();
+        Join<Post, HashtagMapping> hashtagMapping = post.join("hashtagMappingList", JoinType.RIGHT);
 
-  public List<PostResponse> findAllPostByHashtag(PostRequest postRequest) {
-    CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<Long> query = builder.createQuery(Long.class);
-    Root<Post> post = query.from(Post.class);
-    List<Predicate> searchCriteria = new ArrayList<>();
-    Join<Post, HashtagMapping> hashtagMapping = post.join("hashtagMappingList", JoinType.RIGHT);
+        query.select(post.get("seq"));
 
-    query.select(post.get("seq"));
+        if (postRequest.hashtag() != null) {
+            searchCriteria.add(
+                    builder.equal(hashtagMapping.get("hashtag").get("name"), postRequest.hashtag()));
+        }
 
-    if (postRequest.hashtag() != null) {
-      searchCriteria.add(
-          builder.equal(hashtagMapping.get("hashtag").get("name"), postRequest.hashtag()));
+        return entityManager.createQuery(
+                buildCommonQuery(postRequest, searchCriteria, builder, post, query)).getResultList();
     }
 
-    return entityManager.createQuery(
-        buildCommonQuery(postRequest, searchCriteria, builder, post, query)).getResultList();
-  }
 
+    public CriteriaQuery buildCommonQuery(PostRequest postRequest, List<Predicate> searchCriteria,
+                                          CriteriaBuilder builder, Root<Post> post, CriteriaQuery query) {
 
-  public CriteriaQuery buildCommonQuery(PostRequest postRequest, List<Predicate> searchCriteria,
-      CriteriaBuilder builder, Root<Post> post, CriteriaQuery query) {
+        if (postRequest.type() != null) {
+            searchCriteria.add(builder.equal(post.get("type"), SnsType.find(postRequest.type())));
+        }
 
-    if (postRequest.type() != null) {
-      searchCriteria.add(builder.equal(post.get("type"), SnsType.find(postRequest.type())));
+        if (postRequest.searchBy() != null && postRequest.search() != null) {
+            final String parameter = '%' + postRequest.search() + '%';
+
+            if (!postRequest.searchBy().contains(",")) {
+                searchCriteria.add(builder.like(post.get(postRequest.searchBy()), parameter));
+            }
+
+            if (postRequest.searchBy().contains(",")) {
+                String[] searchArray = postRequest.searchBy().split(",");
+
+                searchCriteria.add(builder.or(
+                        builder.like(post.get(searchArray[0]), parameter),
+                        builder.like(post.get(searchArray[1]), parameter)
+                ));
+            }
+        }
+
+        query.where(builder.and(searchCriteria.toArray(new Predicate[0])));
+
+        if (postRequest.order().equals(Order.ASC.name())) {
+            query.orderBy(builder.asc(post.get(postRequest.orderBy())));
+        }
+
+        if (postRequest.order().equals(Order.DESC.name())) {
+            query.orderBy(builder.desc(post.get(postRequest.orderBy())));
+        }
+
+        return query;
     }
-
-    if (postRequest.searchBy() != null && postRequest.search() != null) {
-      final String parameter = '%' + postRequest.search() + '%';
-
-      if(!postRequest.searchBy().contains(",")){
-        searchCriteria.add(builder.like(post.get(postRequest.searchBy()), parameter));
-      }
-
-      if(postRequest.searchBy().contains(",")){
-        String[] searchArray = postRequest.searchBy().split(",");
-
-        searchCriteria.add(builder.or(
-            builder.like(post.get(searchArray[0]),parameter),
-            builder.like(post.get(searchArray[1]), parameter)
-        ));
-      }
-    }
-
-    query.where(builder.and(searchCriteria.toArray(new Predicate[0])));
-
-    if (postRequest.order().equals(Order.ASC.name())) {
-      query.orderBy(builder.asc(post.get(postRequest.orderBy())));
-    }
-
-    if (postRequest.order().equals(Order.DESC.name())) {
-      query.orderBy(builder.desc(post.get(postRequest.orderBy())));
-    }
-
-    return query;
-  }
 }

--- a/src/main/java/com/wanted/sns/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/wanted/sns/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,102 @@
+package com.wanted.sns.repository;
+
+import com.wanted.sns.domain.HashtagMapping;
+import com.wanted.sns.domain.Order;
+import com.wanted.sns.domain.Post;
+import com.wanted.sns.domain.SnsType;
+import com.wanted.sns.dto.PostRequest;
+import com.wanted.sns.dto.PostResponse;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PostCustomRepositoryImpl implements PostCustomRepository {
+
+  private final EntityManager entityManager;
+
+  @Override
+  public List<PostResponse> findAllPostBy(PostRequest postRequest) {
+    CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+    CriteriaQuery<PostResponse> query = builder.createQuery(PostResponse.class);
+    Root<Post> post = query.from(Post.class);
+
+    int pageOffset = postRequest.page() * postRequest.pageCount();
+    List<Predicate> searchCriteria = new ArrayList<>();
+
+    query.select(builder.construct(PostResponse.class, post));
+
+    if (postRequest.hashtag() != null) {
+      searchCriteria.add(post.get("seq").in(findAllPostByHashtag(postRequest)));
+    }
+
+    return entityManager
+        .createQuery(buildCommonQuery(postRequest, searchCriteria, builder, post, query))
+        .setFirstResult(pageOffset)
+        .setMaxResults(postRequest.pageCount())
+        .getResultList();
+  }
+
+  public List<PostResponse> findAllPostByHashtag(PostRequest postRequest) {
+    CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+    CriteriaQuery<Long> query = builder.createQuery(Long.class);
+    Root<Post> post = query.from(Post.class);
+    List<Predicate> searchCriteria = new ArrayList<>();
+    Join<Post, HashtagMapping> hashtagMapping = post.join("hashtagMappingList", JoinType.RIGHT);
+
+    query.select(post.get("seq"));
+
+    if (postRequest.hashtag() != null) {
+      searchCriteria.add(
+          builder.equal(hashtagMapping.get("hashtag").get("name"), postRequest.hashtag()));
+    }
+
+    return entityManager.createQuery(
+        buildCommonQuery(postRequest, searchCriteria, builder, post, query)).getResultList();
+  }
+
+
+  public CriteriaQuery buildCommonQuery(PostRequest postRequest, List<Predicate> searchCriteria,
+      CriteriaBuilder builder, Root<Post> post, CriteriaQuery query) {
+
+    if (postRequest.type() != null) {
+      searchCriteria.add(builder.equal(post.get("type"), SnsType.find(postRequest.type())));
+    }
+
+    if (postRequest.searchBy() != null && postRequest.search() != null) {
+      final String parameter = '%' + postRequest.search() + '%';
+
+      if(!postRequest.searchBy().contains(",")){
+        searchCriteria.add(builder.like(post.get(postRequest.searchBy()), parameter));
+      }
+
+      if(postRequest.searchBy().contains(",")){
+        String[] searchArray = postRequest.searchBy().split(",");
+
+        searchCriteria.add(builder.or(
+            builder.like(post.get(searchArray[0]),parameter),
+            builder.like(post.get(searchArray[1]), parameter)
+        ));
+      }
+    }
+
+    query.where(builder.and(searchCriteria.toArray(new Predicate[0])));
+
+    if (postRequest.order().equals(Order.ASC.name())) {
+      query.orderBy(builder.asc(post.get(postRequest.orderBy())));
+    }
+
+    if (postRequest.order().equals(Order.DESC.name())) {
+      query.orderBy(builder.desc(post.get(postRequest.orderBy())));
+    }
+
+    return query;
+  }
+}

--- a/src/main/java/com/wanted/sns/repository/PostRepository.java
+++ b/src/main/java/com/wanted/sns/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.sns.repository;
+
+import com.wanted.sns.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
+}

--- a/src/main/java/com/wanted/sns/service/PostService.java
+++ b/src/main/java/com/wanted/sns/service/PostService.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class PostService {
 
-  private final PostRepository postRepository;
+    private final PostRepository postRepository;
 
-  public List<PostResponse> getPostList(PostRequest postRequest){
-    return postRepository.findAllPostBy(postRequest);
-  }
+    public List<PostResponse> getPostList(PostRequest postRequest) {
+        return postRepository.findAllPostBy(postRequest);
+    }
 
 }

--- a/src/main/java/com/wanted/sns/service/PostService.java
+++ b/src/main/java/com/wanted/sns/service/PostService.java
@@ -1,0 +1,20 @@
+package com.wanted.sns.service;
+
+import com.wanted.sns.dto.PostRequest;
+import com.wanted.sns.dto.PostResponse;
+import com.wanted.sns.repository.PostRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PostService {
+
+  private final PostRepository postRepository;
+
+  public List<PostResponse> getPostList(PostRequest postRequest){
+    return postRepository.findAllPostBy(postRequest);
+  }
+
+}

--- a/src/main/resources/h2/data.sql
+++ b/src/main/resources/h2/data.sql
@@ -1,0 +1,23 @@
+INSERT INTO POST(title, type, content, view_count, share_count, like_count, created_at, updated_at)
+values ('제목1', 'FACEBOOK', '근로자는 근로조건의 향상을 위하여 자주적인 단결권·단체교섭권 및 단체행동권을 가진다.', 10, 20, 30, now(), now());
+INSERT INTO POST(title, type, content, view_count, share_count, like_count, created_at, updated_at)
+values ('제목2', 'FACEBOOK', '국무총리는 국무위원의 해임을 대통령에게 건의할 수 있다. 모든 국민은 보건에 관하여 국가의 보호를 받는다.', 0, 0, 0, TIMESTAMPADD(hour,1,now()), TIMESTAMPADD(hour,1,now()));
+INSERT INTO POST(title, type, content, view_count, share_count, like_count, created_at, updated_at)
+values ('제목3', 'FACEBOOK', '모든 국민은 법률이 정하는 바에 의하여 선거권을 가진다. 지방자치단체는 주민의 복리에 관한 사무를 처리하고 재산을 관리하며, 법령의 범위안에서 자치에 관한 규정을 제정할 수 있다.', 20, 20, 10, TIMESTAMPADD(hour,2,now()), TIMESTAMPADD(hour,2,now()));
+INSERT INTO POST(title, type, content, view_count, share_count, like_count, created_at, updated_at)
+values ('제목1', 'INSTAGRAM', '대통령은 법률안의 일부에 대하여 또는 법률안을 수정하여 재의를 요구할 수 없다.', 0, 0, 0, TIMESTAMPADD(hour,3,now()), TIMESTAMPADD(hour,4,now()));
+INSERT INTO POST(title, type, content, view_count, share_count, like_count, created_at, updated_at)
+values ('제목2', 'TWITTER', '대통령의 선거에 관한 사항은 법률로 정한다. 감사원은 원장을 포함한 5인 이상 11인 이하의 감사위원으로 구성한다.', 20, 20, 10, TIMESTAMPADD(day,1,now()), TIMESTAMPADD(day,1,now()));
+
+INSERT INTO HASHTAG(name) values('해시태그1');
+INSERT INTO HASHTAG(name) values('해시태그2');
+INSERT INTO HASHTAG(name) values('해시태그3');
+
+INSERT INTO HASHTAG_MAPPING(SEQ_POST, SEQ_HASHTAG) values(1,1);
+INSERT INTO HASHTAG_MAPPING(SEQ_POST, SEQ_HASHTAG) values(1,2);
+INSERT INTO HASHTAG_MAPPING(SEQ_POST, SEQ_HASHTAG) values(1,3);
+INSERT INTO HASHTAG_MAPPING(SEQ_POST, SEQ_HASHTAG) values(2,1);
+INSERT INTO HASHTAG_MAPPING(SEQ_POST, SEQ_HASHTAG) values(2,2);
+INSERT INTO HASHTAG_MAPPING(SEQ_POST, SEQ_HASHTAG) values(3,3);
+INSERT INTO HASHTAG_MAPPING(SEQ_POST, SEQ_HASHTAG) values(4,2);
+INSERT INTO HASHTAG_MAPPING(SEQ_POST, SEQ_HASHTAG) values(5,1);

--- a/src/test/java/com/wanted/sns/SnsApplicationTests.java
+++ b/src/test/java/com/wanted/sns/SnsApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class SnsApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/com/wanted/sns/post/PostReadTest.java
+++ b/src/test/java/com/wanted/sns/post/PostReadTest.java
@@ -1,0 +1,68 @@
+package com.wanted.sns.post;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class PostReadTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void beforeEach(){
+        RestAssured.port = port;
+    }
+
+    @DisplayName("게시글 목록 조회 테스트")
+    @Nested
+    public class getPostList{
+        @DisplayName("기본 최신순 목록 조회")
+        @Test
+        public void getDefault(){
+            RestAssured.when().get("/post")
+                    .then()
+                        .assertThat()
+                        .statusCode(HttpStatus.OK.value())
+                    .log().all();
+        }
+
+        @DisplayName("해시태그 검색")
+        @Test
+        public void searchHashtag(){
+            RestAssured.when().get("/post?hashtag=해시태그1")
+                    .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.OK.value())
+                    .log().all();
+        }
+
+        @DisplayName("제목 + 내용 검색")
+        @Test
+        public void searchBy(){
+            RestAssured.when().get("/post?searchBy=title,content&search=법률")
+                    .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.OK.value())
+                    .log().all();
+        }
+
+        @DisplayName("좋아요순으로 정렬")
+        @Test
+        public void orderBy(){
+            RestAssured.when().get("/post?orderBy=likeCount&order=desc")
+                    .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.OK.value())
+                    .log().all();
+        }
+    }
+
+}

--- a/src/test/java/com/wanted/sns/repository/PostRepositoryTest.java
+++ b/src/test/java/com/wanted/sns/repository/PostRepositoryTest.java
@@ -3,26 +3,22 @@ package com.wanted.sns.repository;
 import com.wanted.sns.domain.Order;
 import com.wanted.sns.dto.PostRequest;
 import com.wanted.sns.dto.PostResponse;
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@Transactional
-@SpringBootTest
+@DataJpaTest
 public class PostRepositoryTest {
 
     @Autowired
     PostRepository postRepository;
 
-    @Autowired
-    EntityManager entityManager;
-
+    @DisplayName("게시글 목록 조회 테스트")
     @Test
-    public void getPosts() {
+    public void getPostList() {
         String searchBy = "title";
         String search = "1";
         String hashtag = "해시태그1";

--- a/src/test/java/com/wanted/sns/repository/PostRepositoryTest.java
+++ b/src/test/java/com/wanted/sns/repository/PostRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.wanted.sns.repository;
+
+import com.wanted.sns.dto.PostRequest;
+import com.wanted.sns.dto.PostResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+public class PostRepositoryTest {
+
+  @Autowired
+  PostRepository postRepository;
+
+  @Test
+  public void getPosts(){
+    PostRequest postRequest = PostRequest.builder()
+        .hashtag("해시태그1")
+        .order("ASC")
+        .orderBy("updatedAt")
+        .searchBy("title")
+        .search("1")
+        .build();
+    List<PostResponse> posts = postRepository.findAllPostBy(postRequest);
+    System.out.println(posts.size());
+  }
+}

--- a/src/test/java/com/wanted/sns/repository/PostRepositoryTest.java
+++ b/src/test/java/com/wanted/sns/repository/PostRepositoryTest.java
@@ -1,8 +1,10 @@
 package com.wanted.sns.repository;
 
+import com.wanted.sns.domain.Order;
 import com.wanted.sns.dto.PostRequest;
 import com.wanted.sns.dto.PostResponse;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,15 +18,28 @@ public class PostRepositoryTest {
   PostRepository postRepository;
 
   @Test
-  public void getPosts(){
+  public void getPosts() {
+    String searchBy = "title";
+    String search = "1";
+    String hashtag = "해시태그1";
+    String order = Order.ASC.name();
+    String orderBy = "updatedAt";
+
     PostRequest postRequest = PostRequest.builder()
-        .hashtag("해시태그1")
-        .order("ASC")
-        .orderBy("updatedAt")
-        .searchBy("title")
-        .search("1")
+        .hashtag(hashtag)
+        .order(order)
+        .orderBy(orderBy)
+        .searchBy(searchBy)
+        .search(search)
         .build();
-    List<PostResponse> posts = postRepository.findAllPostBy(postRequest);
-    System.out.println(posts.size());
+    List<PostResponse> result = postRepository.findAllPostBy(postRequest);
+
+    SoftAssertions.assertSoftly(softAssertions -> {
+      for (PostResponse response : result) {
+        softAssertions.assertThat(response.getTitle())
+            .contains(search);
+      }
+    });
+
   }
 }

--- a/src/test/java/com/wanted/sns/repository/PostRepositoryTest.java
+++ b/src/test/java/com/wanted/sns/repository/PostRepositoryTest.java
@@ -3,6 +3,7 @@ package com.wanted.sns.repository;
 import com.wanted.sns.domain.Order;
 import com.wanted.sns.dto.PostRequest;
 import com.wanted.sns.dto.PostResponse;
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -14,32 +15,35 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 public class PostRepositoryTest {
 
-  @Autowired
-  PostRepository postRepository;
+    @Autowired
+    PostRepository postRepository;
 
-  @Test
-  public void getPosts() {
-    String searchBy = "title";
-    String search = "1";
-    String hashtag = "해시태그1";
-    String order = Order.ASC.name();
-    String orderBy = "updatedAt";
+    @Autowired
+    EntityManager entityManager;
 
-    PostRequest postRequest = PostRequest.builder()
-        .hashtag(hashtag)
-        .order(order)
-        .orderBy(orderBy)
-        .searchBy(searchBy)
-        .search(search)
-        .build();
-    List<PostResponse> result = postRepository.findAllPostBy(postRequest);
+    @Test
+    public void getPosts() {
+        String searchBy = "title";
+        String search = "1";
+        String hashtag = "해시태그1";
+        String order = Order.ASC.getValue();
+        String orderBy = "updatedAt";
 
-    SoftAssertions.assertSoftly(softAssertions -> {
-      for (PostResponse response : result) {
-        softAssertions.assertThat(response.getTitle())
-            .contains(search);
-      }
-    });
+        PostRequest postRequest = PostRequest.builder()
+                .hashtag(hashtag)
+                .order(order)
+                .orderBy(orderBy)
+                .searchBy(searchBy)
+                .search(search)
+                .build();
+        List<PostResponse> result = postRepository.findAllPostBy(postRequest);
 
-  }
+        SoftAssertions.assertSoftly(softAssertions -> {
+            for (PostResponse response : result) {
+                softAssertions.assertThat(response.getTitle())
+                        .contains(search);
+            }
+        });
+    }
+
 }


### PR DESCRIPTION
## 구현내용
- 게시물 목록 조회 및 검색 구현

예시 쿼리:
[GET] /post?pageCount=3&page=0&searchBy=title,content&search=법률&orderBy=updatedAt&hashtag=해시태그1

예시 결과:
``` json
[
    {
        "id": 5,
        "title": "제목2",
        "type": "twitter",
        "content": "대통령의 선거에 관한 사항은 법률로 ",
        "viewCount": 20,
        "likeCount": 10,
        "shareCount": 20,
        "hashtagList": [
            "해시태그1"
        ],
        "updatedAt": "2023-10-31T05:29:44.968809",
        "createdAt": "2023-10-31T05:29:44.968809"
    }
]
```

#### 변경사항
- 쿼리 파라미터를 스네이크 케이스 -> 캐멀 케이스로 구현
- 게시물 테스트 데이터 생성

close #7